### PR TITLE
Remove rise-text attributes

### DIFF
--- a/demo/src/rise-rich-text-dev.html
+++ b/demo/src/rise-rich-text-dev.html
@@ -33,8 +33,7 @@
 
 <body>
 
-  <rise-rich-text value="Hello
-   World!" fontsize="100" multiline="true">
+  <rise-rich-text rich-text="<span style='font-size:100px; color:green'>Hello World!</span>">
   </rise-rich-text>
 
   <script>

--- a/src/rise-rich-text.js
+++ b/src/rise-rich-text.js
@@ -1,12 +1,8 @@
 import { html } from "@polymer/polymer";
-import "@polymer/polymer/lib/elements/dom-if.js";
 import { RiseElement } from "rise-common-component/src/rise-element.js";
 import { version } from "./rise-rich-text-version.js";
 
-const MIN_TEXT_SIZE = 1;
-const MAX_TEXT_SIZE = 200;
-
-export default class RiseText extends RiseElement {
+export default class RiseRichText extends RiseElement {
 
   static get template() {
     return html``;
@@ -17,28 +13,6 @@ export default class RiseText extends RiseElement {
       richText: {
         type: String,
         observer: "_richTextChanged"
-      },
-      value: {
-        type: String,
-        observer: "_valueChanged"
-      },
-      fontsize: {
-        type: Number,
-        observer: "_fontsizeChanged"
-      },
-      minfontsize: {
-        type: Number,
-        value: MIN_TEXT_SIZE,
-        observer: "_checkFontSize"
-      },
-      maxfontsize: {
-        type: Number,
-        value: MAX_TEXT_SIZE,
-        observer: "_checkFontSize"
-      },
-      multiline: {
-        type: Boolean,
-        value: false
       }
     };
   }
@@ -52,84 +26,7 @@ export default class RiseText extends RiseElement {
 
   _richTextChanged(newValue, oldValue) {
     this._refresh();
-    this._sendTextEvent( RiseText.EVENT_DATA_UPDATE, {newValue, oldValue, content: "html"});
-  }
-
-  _valueChanged(newValue, oldValue) {
-    if (!this._richTextIsSet()) {
-      this._refresh();
-    }
-    this._sendTextEvent( RiseText.EVENT_DATA_UPDATE, {newValue, oldValue, fontsize: this.fontsize});
-  }
-
-  _fontsizeChanged() {
-    this.validFont = this._checkFontSize();
-
-    if (this.validFont) {
-      if (!this._richTextIsSet()) {
-        this._refresh();
-      }
-      this._sendTextEvent( RiseText.EVENT_DATA_UPDATE, {newValue: this.value, oldValue: this.value, fontsize: this.fontsize});
-    }
-  }
-
-  _checkFontSize() {
-    let validParameters = true;
-
-    if (this.minfontsize && this.minfontsize < MIN_TEXT_SIZE) {
-      super.log( "error", "Minimum font size must be greater than 0", { min: this.minfontsize } );
-      this._sendTextEvent( RiseText.EVENT_DATA_ERROR, {
-        message: "Minimum font size must be greater 0",
-        min: this.minfontsize
-      });
-
-      validParameters = false;
-    }
-
-    if (this.maxfontsize && this.maxfontsize < MIN_TEXT_SIZE) {
-      super.log( "error", "Maximum font size must be greater than 0", { max: this.maxfontsize } );
-      this._sendTextEvent( RiseText.EVENT_DATA_ERROR, {
-        message: "Maximum font size must be greater 0",
-        max: this.maxfontsize
-      });
-
-      validParameters = false;
-    }
-
-    if (this.minfontsize && this.maxfontsize && this.maxfontsize < this.minfontsize) {
-      super.log( "error", "Maximum font size must be greater than minimum", { min: this.minfontsize, max: this.maxfontsize } );
-      this._sendTextEvent( RiseText.EVENT_DATA_ERROR, {
-        message: "Maximum font size must be greater than minimum",
-        min: this.minfontsize,
-        max: this.maxfontsize
-      });
-
-      validParameters = false;
-    }
-
-    if (this.fontsize && this.fontsize < this.minfontsize) {
-      super.log( "error", "Font size must be greater than or equal to the minimum", { min: this.minfontsize, size: this.fontsize } );
-      this._sendTextEvent( RiseText.EVENT_DATA_ERROR, {
-        message: "Font size must be greater than or equal to the minimum",
-        min: this.minfontsize,
-        size: this.fontsize
-      });
-
-      validParameters = false;
-    }
-
-    if (this.fontsize && this.fontsize > this.maxfontsize) {
-      super.log( "error", "Font size must be lower than or equal to the maximum", { max: this.maxfontsize, size: this.fontsize } );
-      this._sendTextEvent( RiseText.EVENT_DATA_ERROR, {
-        message: "Font size must be lower than or equal to the maximum",
-        max: this.maxfontsize,
-        size: this.fontsize
-      });
-
-      validParameters = false;
-    }
-
-    return validParameters;
+    this._sendRichTextEvent( RiseRichText.EVENT_DATA_UPDATE, {newValue, oldValue});
   }
 
   _richTextIsSet() {
@@ -137,36 +34,17 @@ export default class RiseText extends RiseElement {
   }
 
   _refresh() {
-    const css = `
-<style>
-  :host([multiline=true]) span {
-    white-space: pre-wrap;
-  }
-</style>
-    `;
-
-    let html = this.richText;
-
-    //backwards compatibility
-    if (!this._richTextIsSet()) {
-      if (this.validFont) {
-        html = `<span style="font-size: ${this.fontsize}px;">${this.value}</span>`;
-      } else {
-        html = `<span>${this.value}</span>`;
-      }
-    }
-
-    this.shadowRoot.innerHTML = css + html;
+    this.shadowRoot.innerHTML = this.richText;
   }
 
-  _sendTextEvent( eventName, detail ) {
+  _sendRichTextEvent( eventName, detail ) {
     super._sendEvent( eventName, detail );
 
     switch ( eventName ) {
-      case RiseText.EVENT_DATA_ERROR:
+      case RiseRichText.EVENT_DATA_ERROR:
         super._setUptimeError( true );
         break;
-      case RiseText.EVENT_DATA_UPDATE:
+      case RiseRichText.EVENT_DATA_UPDATE:
         super._setUptimeError( false );
         break;
       default:
@@ -174,4 +52,4 @@ export default class RiseText extends RiseElement {
   }
 }
 
-customElements.define("rise-rich-text", RiseText);
+customElements.define("rise-rich-text", RiseRichText);


### PR DESCRIPTION
## Description
Remove rise-text attributes

## Motivation and Context
`rise-rich-text` no longer needs to be backwards compatibile with `rise-text` component

## How Has This Been Tested?
Tested locally using `rise-rich-text-dev.html` page (see readme).

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
