### PR TITLE
Rename property and attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@
 ```
   <rise-rich-text
     id="rise-rich-text-greeting"
-    rich-text="<span style='font-size:100px; color:green'>Hello World!</span>">
+    richtext="<span style='font-size:100px; color:green'>Hello World!</span>">
   </rise-rich-text>
 ```
 ##### Plain Text
 ```
   <rise-rich-text
     id="rise-rich-text-greeting" 
-    rich-text="Hello World!">
+    richtext="Hello World!">
   </rise-rich-text>
 ```
 
@@ -31,7 +31,7 @@ This attribute holds a literal value, for example:
   <rise-rich-text
     id="rise-rich-text-greeting"
     label="Greeting"
-    rich-text="Hello World!">
+    richtext="Hello World!">
   </rise-rich-text>
 ```
 
@@ -42,7 +42,7 @@ If it's not set, the label for the component defaults to "Text", which is applie
 This component receives the following list of attributes:
 
 - **id**: ( string / required ): Unique HTMLElement id.
-- **rich-text**: ( string / required ): A plain text or HTML.
+- **richtext**: ( string / required ): A plain text or HTML.
 - **label**: ( string / optional ): An optional label key for the text that will appear in the template editor. See 'Labels' section above.
 - **non-editable**: ( empty / optional ): If present, it indicates this component is not available for customization in the template editor.
 

--- a/demo/src/rise-rich-text-dev.html
+++ b/demo/src/rise-rich-text-dev.html
@@ -33,7 +33,7 @@
 
 <body>
 
-  <rise-rich-text rich-text="<span style='font-size:100px; color:green'>Hello World!</span>">
+  <rise-rich-text richtext="<span style='font-size:100px; color:green'>Hello World!</span>">
   </rise-rich-text>
 
   <script>

--- a/demo/src/rise-rich-text.html
+++ b/demo/src/rise-rich-text.html
@@ -35,7 +35,7 @@
 
 <body>
 
-  <rise-rich-text rich-text="Hello World!">
+  <rise-rich-text richtext="Hello World!">
   </rise-rich-text>
 
   <script>

--- a/src/rise-rich-text.js
+++ b/src/rise-rich-text.js
@@ -10,7 +10,7 @@ export default class RiseRichText extends RiseElement {
 
   static get properties() {
     return {
-      richText: {
+      richtext: {
         type: String,
         observer: "_richTextChanged"
       }
@@ -30,7 +30,7 @@ export default class RiseRichText extends RiseElement {
   }
 
   _refresh() {
-    this.shadowRoot.innerHTML = this.richText;
+    this.shadowRoot.innerHTML = this.richtext;
   }
 }
 

--- a/test/rise-rich-text-test.html
+++ b/test/rise-rich-text-test.html
@@ -25,7 +25,7 @@
 
     <test-fixture id="StaticValueTestFixture">
       <template>
-        <rise-rich-text rich-text="Hello World"></rise-rich-text>
+        <rise-rich-text richtext="Hello World"></rise-rich-text>
       </template>
     </test-fixture>
 
@@ -58,13 +58,13 @@
           sandbox.restore();
         });
 
-        test('setting "rich-text" attribute on the element works', () => {
-          assert.equal(element.richText, 'Hello World');
+        test('setting "richtext" attribute on the element works', () => {
+          assert.equal(element.richtext, 'Hello World');
         });
 
-        test('updating "rich-text" attribute on the element works', (done) => {
-          element.setAttribute('rich-text', 'New Value with special characters > < & " \' / ');
-          assert.equal(element.richText, 'New Value with special characters > < & " \' / ');
+        test('updating "richtext" attribute on the element works', (done) => {
+          element.setAttribute('richtext', 'New Value with special characters > < & " \' / ');
+          assert.equal(element.richtext, 'New Value with special characters > < & " \' / ');
 
           element.addEventListener('data-update', function (event) {
             assert.equal(event.type, 'data-update');
@@ -73,12 +73,12 @@
             done();
           });
 
-          element.setAttribute('rich-text', 'New Value 2');
+          element.setAttribute('richtext', 'New Value 2');
         });
 
-        test('updating "richText" property on the element works', (done) => {
-          element['richText'] = 'New Value with special characters > < & " \' / ';
-          assert.equal(element.richText, 'New Value with special characters > < & " \' / ');
+        test('updating "richtext" property on the element works', (done) => {
+          element['richtext'] = 'New Value with special characters > < & " \' / ';
+          assert.equal(element.richtext, 'New Value with special characters > < & " \' / ');
 
           element.addEventListener('data-update', function (event) {
             assert.equal(event.type, 'data-update');
@@ -87,7 +87,7 @@
             done();
           });
 
-          element['richText'] = 'New Value 2';
+          element['richtext'] = 'New Value 2';
         });
 
       });


### PR DESCRIPTION
## Description
Rename "richText" property to "richtext" and "rich-text" attribute to "richtext".

## Motivation and Context
There is some inconsistency in the logic of how blueprint is generated and how data is save. Blueprint is generated based on attribute, but then in the code we set property, hence they have to have exactly the same name.

## How Has This Been Tested?
With automated tests and visually by running the demo page.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
