### PR TITLE
Load google fonts

### DIFF
--- a/src/rise-rich-text.js
+++ b/src/rise-rich-text.js
@@ -13,6 +13,10 @@ export default class RiseRichText extends RiseElement {
       richtext: {
         type: String,
         observer: "_richTextChanged"
+      },
+      googlefonts: {
+        type: Array,
+        observer: "_googleFontsChanged"
       }
     };
   }
@@ -21,12 +25,23 @@ export default class RiseRichText extends RiseElement {
     super();
 
     this._setVersion( version );
-    this.validFont = false;
+
+    //create empty link element so it can be re-used when googlefonts change
+    this.googleFontsLink = document.createElement("link");
+    this.googleFontsLink.rel  = "stylesheet";
+    this.googleFontsLink.type = "text/css";
+    document.head.appendChild(this.googleFontsLink);
   }
 
   _richTextChanged(newValue, oldValue) {
     this._refresh();
     super._sendEvent( RiseRichText.EVENT_DATA_UPDATE, {newValue, oldValue});
+  }
+
+  _googleFontsChanged() {
+    if (this.googlefonts && this.googlefonts.length) {
+      this.googleFontsLink.href =  "https://fonts.googleapis.com/css2?display=swap&family=" + encodeURI(this.googlefonts.join("&family="));
+    }
   }
 
   _refresh() {


### PR DESCRIPTION
## Description
- Add `googlefonts` property to pass a list of Google Fonts used in the `richtext`
- Load Google Fonts using `<link>` element
- Re-use the same `<link>` element for loading fonts when fonts change

## Motivation and Context
Support Google Fonts

## How Has This Been Tested?
Tested visually on local machine.  

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
