### PR TITLE
Fix blinking in Editor Preview

### DIFF
--- a/src/rise-rich-text.js
+++ b/src/rise-rich-text.js
@@ -47,9 +47,13 @@ export default class RiseRichText extends RiseElement {
       // Using observer that monitors array mutations https://polymer-library.polymer-project.org/3.0/docs/devguide/observers#array-observation
       // does not fully solve the problem because changeRecord parameter is unreliable.
       if (googleFontsUrl !== this.googleFontsLink.href) {
-        this.googleFontsLink.href =  googleFontsUrl;
+        this._setGoogleFontsLinkHref(googleFontsUrl);
       }
     }
+  }
+
+  _setGoogleFontsLinkHref(value) {
+    this.googleFontsLink.href =  value;
   }
 
   _refresh() {

--- a/src/rise-rich-text.js
+++ b/src/rise-rich-text.js
@@ -40,7 +40,15 @@ export default class RiseRichText extends RiseElement {
 
   _googleFontsChanged() {
     if (this.googlefonts && this.googlefonts.length) {
-      this.googleFontsLink.href =  "https://fonts.googleapis.com/css2?display=swap&family=" + encodeURI(this.googlefonts.join("&family="));
+      const googleFontsUrl = "https://fonts.googleapis.com/css2?display=swap&family=" + encodeURI(this.googlefonts.join("&family="));
+
+      // Check if URL has changed becase _googleFontsChanged is triggered every time when 
+      // googlefonts or richtext properties change. It causes unecessary blinking in Editor preview.
+      // Using observer that monitors array mutations https://polymer-library.polymer-project.org/3.0/docs/devguide/observers#array-observation
+      // does not fully solve the problem because changeRecord parameter is unreliable.
+      if (googleFontsUrl !== this.googleFontsLink.href) {
+        this.googleFontsLink.href =  googleFontsUrl;
+      }
     }
   }
 

--- a/test/rise-rich-text-test.html
+++ b/test/rise-rich-text-test.html
@@ -91,14 +91,23 @@
         });
 
         test('updating "googlefonts" property changes link url', () => {
+          var stub = sandbox.stub(element, '_setGoogleFontsLinkHref');
           element['googlefonts'] = ['font_a', 'font_b'];
-          assert.equal(element.googleFontsLink.href, 'https://fonts.googleapis.com/css2?display=swap&family=font_a&family=font_b');
+          assert.equal(stub.callCount, 1);
+          assert.equal(stub.args[0][0], 'https://fonts.googleapis.com/css2?display=swap&family=font_a&family=font_b');
         });
 
         test('clearing "googlefonts" property should not change link url', () => {
-          element['googlefonts'] = ['font_a', 'font_b'];
+          var stub = sandbox.stub(element, '_setGoogleFontsLinkHref');
           element['googlefonts'] = [];
-          assert.equal(element.googleFontsLink.href, 'https://fonts.googleapis.com/css2?display=swap&family=font_a&family=font_b');
+          assert.equal(stub.callCount, 0);
+        });
+
+        test('changing "googlefonts" property to the same value should not change link url', () => {
+          var stub = sandbox.spy(element, '_setGoogleFontsLinkHref');
+          element['googlefonts'] = ['font_a', 'font_b'];
+          element['googlefonts'] = ['font_a', 'font_b'];
+          assert.equal(stub.callCount, 1);
         });
       });
     </script>


### PR DESCRIPTION
## Description
- Fix blinking in Editor Preview
- Add `_setGoogleFontsLinkHref` function so the change of the variable can be unit tested

## Motivation and Context
Improve usability

## How Has This Been Tested?
Visually and with unit test 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
